### PR TITLE
Changed sort order to Numerical to correctly sort 8-9-10-11 sequences.

### DIFF
--- a/c-sharp/ImageMerger/ImageLoader.cs
+++ b/c-sharp/ImageMerger/ImageLoader.cs
@@ -4,12 +4,35 @@
     using System.Collections.Generic;
     using System.Drawing;
     using System.IO;
+    using System.Text.RegularExpressions;
 
     public class ImageLoader
     {
         private ImageLoader()
         {
             throw new Exception("No need to create an object of this class, all its methods are static.");
+        }
+
+        public static void NumericalSort(string[] ar)
+        {
+            Regex rgx = new Regex("([^0-9]*)([0-9]+)");
+            Array.Sort(ar, (a, b) =>
+            {
+                var ma = rgx.Matches(a);
+                var mb = rgx.Matches(b);
+                for (int i = 0; i < ma.Count; ++i)
+                {
+                    int ret = ma[i].Groups[1].Value.CompareTo(mb[i].Groups[1].Value);
+                    if (ret != 0)
+                        return ret;
+
+                    ret = int.Parse(ma[i].Groups[2].Value) - int.Parse(mb[i].Groups[2].Value);
+                    if (ret != 0)
+                        return ret;
+                }
+
+                return 0;
+            });
         }
 
         public static void DisposeImages(List<Bitmap> images)
@@ -23,6 +46,7 @@
         public static List<string> ListFiles(string folderPath, string whitelistFilter, string blacklistFilter="")
         {
             string[] files = Directory.GetFiles(folderPath);
+            NumericalSort(files);
             Console.WriteLine("Found {0} files in " + folderPath, files.Length);
             // Console.WriteLine(String.Join(", ", files));
             List<string> list = new List<string>();


### PR DESCRIPTION
Some years ago I added sorting to correct numerical sorting.
I have re-added it to the current master.
A raised issue remembered me that I had fixed it, and hereby my contribution.